### PR TITLE
feat: add database seeds

### DIFF
--- a/backend/src/database/seeds/20240614055941-lessons.js
+++ b/backend/src/database/seeds/20240614055941-lessons.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { faker } = require("@faker-js/faker");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const lessons = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      name: `Lesson ${i + 1}`,
+      previous_lesson: i > 1 ? i - 1 : null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }));
+
+    await queryInterface.bulkInsert("lessons", lessons, {});
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("lessons", null, {});
+  },
+};

--- a/backend/src/database/seeds/20240614060715-users.js
+++ b/backend/src/database/seeds/20240614060715-users.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { faker } = require("@faker-js/faker");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const users = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      nickname: faker.word.adjective({ length: { min: 1, max: 20 } }),
+      checkpoint: 1,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }));
+
+    await queryInterface.bulkInsert("users", users, {});
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("users", null, {});
+  },
+};

--- a/backend/src/database/seeds/20240614061033-exercises.js
+++ b/backend/src/database/seeds/20240614061033-exercises.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const { faker } = require("@faker-js/faker");
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const exercisesData = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      lesson_id: Math.floor(i / 10) + 1,
+      question: faker.lorem.words(3),
+      created_at: new Date(),
+      updated_at: new Date(),
+    }));
+
+    await queryInterface.bulkInsert("exercises", exercisesData, {});
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete("exercises", null, {});
+  },
+};

--- a/backend/src/database/seeds/20240614061355-exercises-choices.js
+++ b/backend/src/database/seeds/20240614061355-exercises-choices.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const { faker } = require("@faker-js/faker");
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const exercises = await queryInterface.sequelize.query(
+      `SELECT id from exercises;`
+    );
+
+    const exerciseChoicesData = [];
+    let idCounter = 1;
+
+    exercises[0].forEach((exercise) => {
+      for (let i = 0; i < 4; i++) {
+        exerciseChoicesData.push({
+          id: idCounter++,
+          choice_id: i + 1,
+          choice_text: faker.lorem.words(3),
+          is_correct: i === 0,
+          exercise_id: exercise.id,
+          created_at: new Date(),
+          updated_at: new Date(),
+        });
+      }
+    });
+
+    await queryInterface.bulkInsert(
+      "exercise_choices",
+      exerciseChoicesData,
+      {}
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete("exercise_choices", null, {});
+  },
+};


### PR DESCRIPTION
database seeds for creating "realistic" mock data (in the sense that, for example, the exercises_choices are created based on the already existent exercises in the database, previously created (based on their timestamps).